### PR TITLE
fix(runtime): validate observed-info counts before TrialSimulator

### DIFF
--- a/R/server/sequential_outputs.R
+++ b/R/server/sequential_outputs.R
@@ -585,7 +585,7 @@ output$gs_round_entry_ui <- renderUI({
           tags$th("Current Alpha"),
           tags$th("Planned Information Fraction"),
           tags$th("Planned Max Info"),
-          tags$th("Observed Info"),
+          tags$th("Observed Event Count"),
           tags$th("Previous Saved Result"),
           tags$th("Boundary p"),
           tags$th("Entered One-Sided p"),
@@ -599,7 +599,12 @@ output$gs_round_entry_ui <- renderUI({
           if (!is.finite(planned_max_info) || planned_max_info <= 0) {
             planned_max_info <- 100
           }
-          default_observed_info <- display_state$actionable_rows$timing[[i]] * planned_max_info
+          # The runtime path records a whole-number observed count, while the
+          # planned information fraction remains design-only guidance.
+          default_observed_info <- max(
+            1L,
+            as.integer(round(display_state$actionable_rows$timing[[i]] * planned_max_info))
+          )
           tags$tr(
             tags$td(tags$strong(display_state$actionable_rows$hypothesis[[i]])),
             tags$td(
@@ -613,13 +618,19 @@ output$gs_round_entry_ui <- renderUI({
             tags$td(format_plain_number(display_state$actionable_rows$timing[[i]])),
             tags$td(format_plain_number(planned_max_info)),
             tags$td(
-              numericInput(
-                inputId = paste0("gs_round_info_", key),
-                label = NULL,
-                value = as.numeric(default_observed_info),
-                min = 0,
-                step = 1,
-                width = "100%"
+              tagList(
+                numericInput(
+                  inputId = paste0("gs_round_info_", key),
+                  label = NULL,
+                  value = as.numeric(default_observed_info),
+                  min = 0,
+                  step = 1,
+                  width = "100%"
+                ),
+                tags$div(
+                  class = "gs-inline-note",
+                  "Actual whole-number event/patient count for this look."
+                )
               )
             ),
             tags$td(last_result_lookup[[key]]),
@@ -651,7 +662,11 @@ output$gs_round_entry_ui <- renderUI({
         class = "gs-inline-note",
         "Only active, testable hypotheses are shown here. Inactive rows are hidden."
       )
-    }
+    },
+    tags$div(
+      class = "gs-inline-note",
+      "Observed Event Count is the actual whole-number count at that look. Planned Information Fraction is design guidance only."
+    )
   )
 })
 

--- a/R/server/sequential_runtime_helpers.R
+++ b/R/server/sequential_runtime_helpers.R
@@ -37,6 +37,8 @@ set_gs_round_feedback <- function(text = NULL, type = c("success", "error")) {
   invisible(NULL)
 }
 
+# TrialSimulator expects an integer event/patient count at runtime submission,
+# not the planned information fraction or a derived decimal.
 gs_require_observed_info_count <- function(observed_info, hypothesis, hypothesis_stage) {
   observed_info <- suppressWarnings(as.numeric(observed_info))
   hypothesis_stage <- coerce_scalar_integer(hypothesis_stage, default = NA_integer_, minimum = 1L)

--- a/R/server/sequential_runtime_helpers.R
+++ b/R/server/sequential_runtime_helpers.R
@@ -37,6 +37,18 @@ set_gs_round_feedback <- function(text = NULL, type = c("success", "error")) {
   invisible(NULL)
 }
 
+gs_require_observed_info_count <- function(observed_info, hypothesis, hypothesis_stage) {
+  observed_info <- suppressWarnings(as.numeric(observed_info))
+  hypothesis_stage <- coerce_scalar_integer(hypothesis_stage, default = NA_integer_, minimum = 1L)
+  if (!is.finite(observed_info) || observed_info <= 0 || abs(observed_info - round(observed_info)) > 1e-8) {
+    stop(sprintf(
+      "Enter a positive whole-number observed information count for %s look %s.",
+      as.character(hypothesis[[1]]),
+      hypothesis_stage
+    ))
+  }
+  as.integer(round(observed_info))
+}
 
 gs_round_submission_feedback_text <- function(
   analysis_round,

--- a/R/server/sequential_runtime_helpers.R
+++ b/R/server/sequential_runtime_helpers.R
@@ -6,8 +6,10 @@
 # schedule monotonic?". Nothing here touches the UI directly — these helpers
 # are called by the event handlers in sequential_events.R and by the state
 # reducers in sequential_state.R.
-
-
+#
+# Runtime ownership note: these helpers feed and interpret the live
+# TrialSimulator::GraphicalTesting object. Design-time boundary construction
+# stays in the boundary helper files and does not use these runtime helpers.
 gs_design_alpha_lookup <- function(
   nodes_tbl = if (exists("rv", inherits = TRUE) && !is.null(rv$nodes)) rv$nodes else NULL,
   fallback = NULL
@@ -37,8 +39,10 @@ set_gs_round_feedback <- function(text = NULL, type = c("success", "error")) {
   invisible(NULL)
 }
 
-# TrialSimulator expects an integer event/patient count at runtime submission,
-# not the planned information fraction or a derived decimal.
+# TrialSimulator::GraphicalTesting$test() expects an integer event/patient
+# count in the runtime `info` column. The design-time boundary preview can use
+# information fractions, but the live submission path cannot pass those
+# fractions or a derived decimal through to TrialSimulator.
 gs_require_observed_info_count <- function(observed_info, hypothesis, hypothesis_stage) {
   observed_info <- suppressWarnings(as.numeric(observed_info))
   hypothesis_stage <- coerce_scalar_integer(hypothesis_stage, default = NA_integer_, minimum = 1L)
@@ -110,6 +114,8 @@ gs_rule_choices <- function(include_custom = TRUE) {
 
 
 gs_runtime_spending_code <- function(rule) {
+  # These are TrialSimulator runtime codes. The boundary-preview path keeps the
+  # human-readable rule names and routes through compute_boundary_schedule().
   normalized <- normalize_spending_rule(rule)
   dplyr::case_when(
     identical(normalized, "OF") ~ "asOF",

--- a/R/server/sequential_state.R
+++ b/R/server/sequential_state.R
@@ -161,10 +161,11 @@ collect_round_submission <- function() {
     if (is.na(p_value) || p_value < 0 || p_value > 1) {
       stop(sprintf("Enter a one-sided p-value between 0 and 1 for %s look %s.", ready_rows$hypothesis[[i]], ready_rows$hypothesis_stage[[i]]))
     }
-    observed_info <- read_scalar_numeric_input(paste0("gs_round_info_", schedule_key))
-    if (is.na(observed_info) || observed_info <= 0) {
-      stop(sprintf("Enter a positive observed information value for %s look %s.", ready_rows$hypothesis[[i]], ready_rows$hypothesis_stage[[i]]))
-    }
+    observed_info <- gs_require_observed_info_count(
+      observed_info = read_scalar_numeric_input(paste0("gs_round_info_", schedule_key)),
+      hypothesis = ready_rows$hypothesis[[i]],
+      hypothesis_stage = ready_rows$hypothesis_stage[[i]]
+    )
     runtime_code <- gs_runtime_spending_code(ready_rows$alpha_spending[[i]])
     planned_max_info <- as.numeric(max_info_lookup[[ready_rows$hypothesis[[i]]]])
     if (!is.finite(planned_max_info) || planned_max_info <= 0) {
@@ -176,7 +177,7 @@ collect_round_submission <- function() {
       p = as.numeric(p_value),
       info = as.numeric(observed_info),
       is_final = isTRUE(ready_rows$is_final[[i]]),
-      max_info = as.numeric(planned_max_info),
+      max_info = if (isTRUE(ready_rows$is_final[[i]])) as.numeric(observed_info) else as.numeric(planned_max_info),
       alpha_spent = if (identical(runtime_code, "asUser")) {
         if (isTRUE(ready_rows$is_final[[i]])) {
           1.0

--- a/R/server/sequential_state.R
+++ b/R/server/sequential_state.R
@@ -177,6 +177,8 @@ collect_round_submission <- function() {
       p = as.numeric(p_value),
       info = as.numeric(observed_info),
       is_final = isTRUE(ready_rows$is_final[[i]]),
+      # Final looks must replay the submitted final count; interim looks still
+      # use the finalized design's planned max info.
       max_info = if (isTRUE(ready_rows$is_final[[i]])) as.numeric(observed_info) else as.numeric(planned_max_info),
       alpha_spent = if (identical(runtime_code, "asUser")) {
         if (isTRUE(ready_rows$is_final[[i]])) {

--- a/R/server/sequential_state.R
+++ b/R/server/sequential_state.R
@@ -47,6 +47,9 @@ initialize_batch_gs_object <- function(reset_history = FALSE) {
     return(FALSE)
   }
 
+  # TrialSimulator's runtime object uses package-specific spending codes. The
+  # app's boundary preview keeps the design-time rule names and computes those
+  # boundaries separately from this initialization step.
   rv$alpha_spending <- vapply(plan_tbl$alpha_spending, gs_runtime_spending_code, character(1))
   rv$planned_max_info <- as.numeric(plan_tbl$planned_max_info)
 
@@ -161,6 +164,8 @@ collect_round_submission <- function() {
     if (is.na(p_value) || p_value < 0 || p_value > 1) {
       stop(sprintf("Enter a one-sided p-value between 0 and 1 for %s look %s.", ready_rows$hypothesis[[i]], ready_rows$hypothesis_stage[[i]]))
     }
+    # This is a live TrialSimulator input, not the design-time information
+    # fraction that the boundary preview used to build the planned look table.
     observed_info <- gs_require_observed_info_count(
       observed_info = read_scalar_numeric_input(paste0("gs_round_info_", schedule_key)),
       hypothesis = ready_rows$hypothesis[[i]],
@@ -177,8 +182,10 @@ collect_round_submission <- function() {
       p = as.numeric(p_value),
       info = as.numeric(observed_info),
       is_final = isTRUE(ready_rows$is_final[[i]]),
-      # Final looks must replay the submitted final count; interim looks still
-      # use the finalized design's planned max info.
+      # TrialSimulator replays a final look against the submitted terminal
+      # count. The design-time boundary preview still comes from the finalized
+      # plan; only the frozen runtime history switches max_info at the final
+      # look to preserve the package's replay contract.
       max_info = if (isTRUE(ready_rows$is_final[[i]])) as.numeric(observed_info) else as.numeric(planned_max_info),
       alpha_spent = if (identical(runtime_code, "asUser")) {
         if (isTRUE(ready_rows$is_final[[i]])) {
@@ -239,7 +246,9 @@ collect_round_submission <- function() {
   batch_results <- trajectory_after %>%
     dplyr::transmute(
       # Preserve the package-emitted event order so same-analysis retests stay
-      # in the frozen history exactly as GraphicalTesting processed them.
+      # in the frozen history exactly as GraphicalTesting processed them. These
+      # boundary/decision columns come from TrialSimulator's runtime result,
+      # not from the app's design-time preview table.
       .package_result_order = dplyr::row_number(),
       analysis_round = as.integer(order),
       hypothesis = as.character(hypothesis),

--- a/scripts/verify_group_sequential_reactivity_case.R
+++ b/scripts/verify_group_sequential_reactivity_case.R
@@ -294,6 +294,66 @@ shiny::testServer(server, {
     build_round_submit_log(submission$history_rows),
     fixed = TRUE
   )))
+
+  configure_single_hypothesis_runtime_case <- function(planned_analyses, info_fraction, analysis_round, is_final) {
+    rv$nodes <- tibble::tibble(id = 1L, x = 0, y = 0, hypothesis = "H1", alpha = 0.025)
+    rv$edges <- tibble::tibble(id = integer(), from = integer(), to = integer(), weight = numeric())
+    rv$gs_hypothesis_plan <- sanitize_gs_hypothesis_plan_tbl(tibble::tibble(
+      id = 1L, hypothesis = "H1", planned_analyses = planned_analyses, planned_max_info = 100,
+      alpha_spending = "OF", custom_cumulative_alpha = "", hsd_gamma = -4, haybittle_p1 = 0.0003
+    ))
+    rv$gs_analysis_schedule <- sanitize_gs_analysis_schedule_tbl(tibble::tibble(
+      schedule_key = paste0("1__", seq_along(info_fraction)),
+      analysis_round = analysis_round,
+      hypothesis = "H1",
+      hypothesis_id = 1L,
+      hypothesis_stage = seq_along(info_fraction),
+      planned_analyses = planned_analyses,
+      information_fraction = info_fraction,
+      is_final = is_final
+    ))
+    rv$gs_analysis_history <- empty_gs_analysis_history()
+    rv$ts_object <- NULL
+    rv$ts_summary <- NULL
+    rv$planned_max_info <- numeric(0)
+    set_gs_analysis_schedule_round_signature(rv$gs_analysis_schedule)
+    runtime_inputs <- list(
+      gs_plan_k_1 = planned_analyses,
+      gs_plan_max_info_1 = 100,
+      gs_plan_rule_1 = "OF"
+    )
+    for (i in seq_along(info_fraction)) {
+      runtime_inputs[[paste0("gs_schedule_round_1__", i)]] <- analysis_round[[i]]
+      runtime_inputs[[paste0("gs_schedule_info_1__", i)]] <- as.character(info_fraction[[i]])
+    }
+    runtime_inputs$gs_analysis_round <- as.character(analysis_round[[1]])
+    do.call(session$setInputs, runtime_inputs)
+    rv$gs_boundary_preview <- build_gs_boundary_schedule(notify = FALSE)
+    flush_session()
+    stopifnot(isTRUE(initialize_batch_gs_object(reset_history = TRUE)))
+  }
+
+  configure_single_hypothesis_runtime_case(
+    planned_analyses = 3L,
+    info_fraction = c(1 / 3, 2 / 3, 1),
+    analysis_round = c(1L, 2L, 3L),
+    is_final = c(FALSE, FALSE, TRUE)
+  )
+  session$setInputs(gs_round_info_1__1 = 33.33333, gs_round_p_1__1 = 0.5)
+  flush_session()
+  decimal_error <- tryCatch(collect_round_submission(), error = function(e) e)
+  stopifnot(inherits(decimal_error, "error"))
+  stopifnot(identical(decimal_error$message, "Enter a positive whole-number observed information count for H1 look 1."))
+
+  configure_single_hypothesis_runtime_case(planned_analyses = 1L, info_fraction = 1, analysis_round = 1L, is_final = TRUE)
+  session$setInputs(gs_round_info_1__1 = 120, gs_round_p_1__1 = 0.5)
+  flush_session()
+  final_submission <- collect_round_submission()
+  final_row <- final_submission$history_rows %>% dplyr::slice(1)
+  stopifnot(abs(as.numeric(final_row$observed_info) - 120) < 1e-12)
+  stopifnot(abs(as.numeric(final_row$max_info) - 120) < 1e-12)
+  stopifnot(isTRUE(replay_group_sequential_history(final_submission$history_rows)))
+  stopifnot(abs(as.numeric(rv$gs_analysis_history$max_info[[1]]) - 120) < 1e-12)
 })
 
 cat("Group sequential reactivity regression passed.\n")
@@ -301,4 +361,5 @@ cat("- No-op plan inputs do not rewrite stored plan/schedule state.\n")
 cat("- Invalid transient K input falls back to stored state without boundary recompute.\n")
 cat("- Changing H1 K rebuilds only H1 schedule rows and keeps other hypotheses untouched.\n")
 cat("- Editing one analysis time updates schedule state immediately and auto-cascades later looks.\n")
-cat("- Non-default planned max info drives the default observed info and stays frozen in submitted history.\n")
+cat("- Runtime submission rejects non-integer observed information counts before TrialSimulator is called.\n")
+cat("- Final-look submissions carry the actual observed count into frozen runtime max info for replay.\n")

--- a/scripts/verify_group_sequential_reactivity_case.R
+++ b/scripts/verify_group_sequential_reactivity_case.R
@@ -271,14 +271,21 @@ shiny::testServer(server, {
 
   round_entry_html <- output$gs_round_entry_ui$html
   stopifnot(grepl("gs_round_info_1__1", round_entry_html, fixed = TRUE))
+  stopifnot(grepl("Observed Event Count", round_entry_html, fixed = TRUE))
+  stopifnot(grepl("Actual whole-number event/patient count for this look.", round_entry_html, fixed = TRUE))
+  stopifnot(grepl(
+    "Observed Event Count is the actual whole-number count at that look. Planned Information Fraction is design guidance only.",
+    round_entry_html,
+    fixed = TRUE
+  ))
   stopifnot(grepl("value=\"120\"", round_entry_html, fixed = TRUE))
 
   stopifnot(isTRUE(initialize_batch_gs_object(reset_history = TRUE)))
   session$setInputs(
     gs_analysis_round = "1",
-    gs_round_info_1__1 = 120,
+    gs_round_info_1__1 = 33,
     gs_round_p_1__1 = 0.5,
-    gs_round_info_2__1 = 100,
+    gs_round_info_2__1 = 33,
     gs_round_p_2__1 = 0.5
   )
   flush_session()
@@ -287,7 +294,7 @@ shiny::testServer(server, {
   h1_submission <- submission$history_rows %>%
     dplyr::filter(hypothesis == "H1") %>%
     dplyr::slice(1)
-  stopifnot(abs(as.numeric(h1_submission$observed_info) - 120) < 1e-12)
+  stopifnot(abs(as.numeric(h1_submission$observed_info) - 33) < 1e-12)
   stopifnot(abs(as.numeric(h1_submission$max_info) - 240) < 1e-12)
   stopifnot(any(grepl(
     "Analysis Time 1 / Look 1: alpha at submission 0.01",
@@ -339,6 +346,8 @@ shiny::testServer(server, {
     analysis_round = c(1L, 2L, 3L),
     is_final = c(FALSE, FALSE, TRUE)
   )
+  interim_round_entry_html <- output$gs_round_entry_ui$html
+  stopifnot(grepl("value=\"33\"", interim_round_entry_html, fixed = TRUE))
   session$setInputs(gs_round_info_1__1 = 33.33333, gs_round_p_1__1 = 0.5)
   flush_session()
   decimal_error <- tryCatch(collect_round_submission(), error = function(e) e)
@@ -361,5 +370,6 @@ cat("- No-op plan inputs do not rewrite stored plan/schedule state.\n")
 cat("- Invalid transient K input falls back to stored state without boundary recompute.\n")
 cat("- Changing H1 K rebuilds only H1 schedule rows and keeps other hypotheses untouched.\n")
 cat("- Editing one analysis time updates schedule state immediately and auto-cascades later looks.\n")
+cat("- Analysis entry defaults observed counts to whole numbers and labels them as actual runtime counts.\n")
 cat("- Runtime submission rejects non-integer observed information counts before TrialSimulator is called.\n")
 cat("- Final-look submissions carry the actual observed count into frozen runtime max info for replay.\n")


### PR DESCRIPTION
## Summary

This PR fixes one narrow runtime bug in the group-sequential Analysis workflow on top of the current `dev4` branch.

The issue is that the Analysis workflow can pass a decimal observed-information value such as `33.33333` into `TrialSimulator::GroupSequentialTest$test()`. `TrialSimulator` expects an integer observed count, so the package throws a low-level error. This PR moves that contract check into the app and preserves the submitted final observed count in frozen runtime history.

## Why I am opening this PR now

Hi Han — it has been a while since your feedback on commit `283fd5e` (`Fixed adding new node issue`).

Since then I continued the group-sequential work on `dev4`, and I also made some UI changes without opening PRs early enough. That was not a good review workflow on my side.

I do not want to ask you to re-review the entire `dev4` branch in one pass. This PR is intentionally small and only asks for review of the observed-information runtime fix described below. The next section is background only so you know where the branch stands today.

## Background already on `dev4` (context only, not the review target of this PR)

Since your earlier review, `dev4` has already accumulated broader group-sequential work, including:

- redesign of the group-sequential workflow and finalized-design checkpoint flow
- runtime-state stabilization and same-round recycling fixes
- planned max info / information-fraction handling and additional boundary-schedule work
- modular split of sequential server helpers out of `common_helpers.R`
- more verification scaffolds for runtime and analysis behavior
- several UI wording/layout iterations in the Design and Analysis tabs

I realize those broader changes should have been reviewed in smaller PRs earlier. This PR is my attempt to reset to a smaller, reviewable workflow.

## What this PR changes

This PR only changes the runtime submission contract for observed information:

- validate observed information in app code before calling `TrialSimulator`
- require the submitted value to be a positive whole-number count
- show an app-level hypothesis/look-specific validation error instead of the raw package error
- use the submitted final observed count as runtime `max_info` for final looks so frozen history and replay preserve the actual final-stage runtime contract

## What this PR does not change

- no Analysis-tab layout or wording changes
- no `gsDesign` boundary-preview changes
- no broader cleanup or refactor beyond this runtime bug fix

## Files to review

- `R/server/sequential_runtime_helpers.R`
- `R/server/sequential_state.R`
- `scripts/verify_group_sequential_reactivity_case.R`

## Suggested review focus

If you have time, I would especially appreciate feedback on these points:

- whether app-side validation is the right layer for the observed-information contract
- whether using the submitted final observed count as runtime `max_info` is the correct final-look behavior
- whether there are any other runtime contract checks I should enforce before calling `TrialSimulator`

## Verification run

I ran:

- `Rscript scripts/verify_group_sequential_reactivity_case.R`
- `Rscript scripts/verify_group_sequential_batch_analysis_case.R`

Both passed.


If this PR structure looks reasonable, I will keep the remaining work split into small issue branches and separate UI-facing changes from runtime/statistical fixes.
